### PR TITLE
Update upload-artifact job to v4

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Build project
               run: npm run build
             - name: Upload build artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: build
                   path: build


### PR DESCRIPTION
`upload-artifact@v3` is deprecated and cannot be used anymore, so upgrade to v4.

Ref:
- https://github.com/JaanJah/typescript-template/actions/runs/13681017935/job/38253149057