### PR TITLE
Update checkout and setup-node action to v4

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,8 +4,8 @@ jobs:
     node:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20'
                   check-latest: true


### PR DESCRIPTION
v4 is latest major, no reason to stick with v3.