### PR TITLE
Add permissions to node.yml jobs

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,9 @@ name: node
 on: [push]
 jobs:
     node:
+        permissions:
+          contents: read
+          pull-requests: write
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes https://github.com/JaanJah/typescript-template/issues/181 by making repo contents readonly and pull-requests write perms.