### PR TITLE
Cleanup: Remove leftover jest packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
 				"@jaanjah/prettier-config": "^1.0.1",
 				"@swc/cli": "^0.6.0",
 				"@swc/core": "^1.11.10",
-				"@swc/jest": "^0.2.37",
-				"@types/jest": "^29.5.14",
 				"@types/node": "^22",
 				"husky": "^9.1.7",
 				"lint-staged": "^15.5.0",
@@ -35,184 +33,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-			"integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -847,30 +667,6 @@
 			"integrity": "sha512-5nscYGbme9UzmUhUSctYnpnn8HGAKyLvo40NY6n9dqVasAiUbWISQZ7PXPtH5GF4n0ZWEmQj/C20wkwc4wU+JQ==",
 			"dev": true
 		},
-		"node_modules/@jest/create-cache-key-function": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
-			"integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-			"dev": true,
-			"dependencies": {
-				"jest-get-type": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -878,23 +674,6 @@
 			"dev": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1880,23 +1659,6 @@
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
 			"dev": true
 		},
-		"node_modules/@swc/jest": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.37.tgz",
-			"integrity": "sha512-CR2BHhmXKGxTiFr21DYPRHQunLkX3mNIFGFkxBGji6r9uyIR5zftTOVYj1e0sFNMV2H7mf/+vpaglqaryBtqfQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/create-cache-key-function": "^29.7.0",
-				"@swc/counter": "^0.1.3",
-				"jsonc-parser": "^3.2.0"
-			},
-			"engines": {
-				"npm": ">= 7.0.0"
-			},
-			"peerDependencies": {
-				"@swc/core": "*"
-			}
-		},
 		"node_modules/@swc/types": {
 			"version": "0.1.19",
 			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.19.tgz",
@@ -1937,40 +1699,6 @@
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
 		},
-		"node_modules/@types/istanbul-lib-coverage": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
-			"dev": true
-		},
-		"node_modules/@types/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-			"dev": true,
-			"dependencies": {
-				"@types/istanbul-lib-coverage": "*"
-			}
-		},
-		"node_modules/@types/istanbul-reports": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-			"integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-			"dev": true,
-			"dependencies": {
-				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"node_modules/@types/jest": {
-			"version": "29.5.14",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-			"integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-			"dev": true,
-			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
-			}
-		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1987,27 +1715,6 @@
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
-		},
-		"node_modules/@types/stack-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-			"dev": true
-		},
-		"node_modules/@types/yargs": {
-			"version": "17.0.17",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-			"integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
-			"dev": true,
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@types/yargs-parser": {
-			"version": "21.0.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "6.7.5",
@@ -2904,15 +2611,6 @@
 				"node": ">= 16"
 			}
 		},
-		"node_modules/ci-info": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/cli-cursor": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3205,15 +2903,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -3782,22 +3471,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/expect-type": {
@@ -4930,88 +4603,6 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
-		"node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-get-type": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"dev": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -5040,12 +4631,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
 		"node_modules/keyv": {
@@ -6917,27 +6502,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/stack-utils": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/stack-utils/node_modules/escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/stackback": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
 		"@jaanjah/prettier-config": "^1.0.1",
 		"@swc/cli": "^0.6.0",
 		"@swc/core": "^1.11.10",
-		"@swc/jest": "^0.2.37",
-		"@types/jest": "^29.5.14",
 		"@types/node": "^22",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.5.0",


### PR DESCRIPTION
Jest was offboarded with https://github.com/JaanJah/typescript-template/issues/174, but noticed I didn't remove all relevant dependencies related with jest. This PR removes those too.

Remove:
- `@types/jest`
- `@swc/jest`