### PR TITLE
ci: Adopt Renovate and pin CodeQL action digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: '/language:${{matrix.language}}'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+	"schedule": ["every weekend"],
+	"labels": ["dependencies"],
+	"assignees": ["jaanjah"],
+	"reviewers": ["jaanjah"],
+	"dependencyDashboardApproval": false
+}


### PR DESCRIPTION
## Summary

Migrates dependency automation from **Dependabot** to **Renovate**, matching `manarion-tracker` and the rest of the stack. Part of #348.

- **`renovate.json`** — `config:recommended` + `helpers:pinGitHubActionDigestsToSemver`, weekend schedule, `dependencies` label, assigned/reviewed by @jaanjah.
- **Removes `.github/dependabot.yml`.**
- **Pins `codeql.yml` actions to commit SHAs** (`actions/checkout` → v7.0.0, `github/codeql-action` → v3) so the security workflow can't be silently repointed via a moved tag. Renovate keeps these current going forward.

## Why Renovate

- Groups related updates into fewer PRs (vs. Dependabot's one-per-dep — the repo had 7 open at once).
- Schedules updates (weekends) instead of a constant trickle.
- Automatically **pins GitHub Action digests**, closing the mutable-tag supply-chain gap across all workflows.

## ⚠️ Action required after merge

Renovate only runs if the **Renovate GitHub App is installed** for this repo. If it isn't already (it is for `manarion-tracker`), enable it at <https://github.com/apps/renovate> so updates resume once Dependabot is removed.

## Notes

The 7 open Dependabot PRs are resolved separately: 5 superseded by the Bun migration (#349), TS 6 applied directly there, ESLint 10 held pending an `@jaanjah/eslint-config` release — see #348.

Refs #348
